### PR TITLE
Removed @Override annotation for compatibility with RN 47+

### DIFF
--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewManager.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewManager.java
@@ -1,10 +1,10 @@
 package com.rome2rio.android.reactnativetouchthroughview;
 
-import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
+import com.facebook.react.uimanager.ViewGroupManager;
 
 public class TouchThroughViewManager
-        extends SimpleViewManager<TouchThroughView> {
+        extends ViewGroupManager<TouchThroughView> {
 
     public static final String REACT_CLASS = "R2RTouchThroughView";
 

--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewPackage.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewPackage.java
@@ -24,7 +24,6 @@ public class TouchThroughViewPackage implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
react-native run-android currently throws an error asking the @Override annotation to be removed. Without the annotation the build runs fine.

When using the library with android, we get a "TouchThroughViewManager cannot be cast to ViewGroupManager". Since ViewGroupManager is basically an extension for SimpleViewManager I tried replacing it. So far we did not experience any problems.