### PR TITLE
Upgrade Android native build tools and dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-    classpath 'com.android.tools.build:gradle:2.1.0'
+    classpath 'com.android.tools.build:gradle:3.1.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -26,15 +26,13 @@ allprojects {
 }
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-
-
 android {
-  compileSdkVersion 23
-  buildToolsVersion "23.0.3"
+  compileSdkVersion 27
+  buildToolsVersion "27.1.1"
 
   defaultConfig {
     minSdkVersion 16
-    targetSdkVersion 23
+    targetSdkVersion 27
   }
 
   lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,6 +5,7 @@ apply plugin: 'com.android.library'
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
     classpath 'com.android.tools.build:gradle:3.1.3'
@@ -28,7 +29,7 @@ allprojects {
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 android {
   compileSdkVersion 27
-  buildToolsVersion "27.1.1"
+  buildToolsVersion "27.0.3"
 
   defaultConfig {
     minSdkVersion 16

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewPackage.java
+++ b/android/src/main/java/com/rome2rio/android/reactnativetouchthroughview/TouchThroughViewPackage.java
@@ -3,7 +3,6 @@ package com.rome2rio.android.reactnativetouchthroughview;
 import android.app.Activity;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -21,11 +20,6 @@ public class TouchThroughViewPackage implements ReactPackage {
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Collections.emptyList();
-    }
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }
 


### PR DESCRIPTION
This PR updates several Android build tools, Gradle wrapper and make it compatible with React Native from 0.47+